### PR TITLE
Fix the scib-metrics to 0.4.1

### DIFF
--- a/envs/scib_metrics.yaml
+++ b/envs/scib_metrics.yaml
@@ -28,5 +28,5 @@ dependencies:
     - ml-collections==0.1.0
     - optax==0.1.4
     - orbax<0.1.6
-    - scib-metrics
-    - git+https://github.com/scverse/scanpy.git@main
+    - scib-metrics==0.4.1
+    - git+https://github.com/scverse/scanpy.git


### PR DESCRIPTION
Newer versions (>=v0.5.0) have different API for input parameters, which breaks our code