### PR TITLE
Fix obs index bug in collect module

### DIFF
--- a/workflow/collect/collect_utils.py
+++ b/workflow/collect/collect_utils.py
@@ -31,11 +31,7 @@ def merge_df(
     df_previous,
     same_columns,
     sep='_',
-    obs_index_col=None,
 ):
-    if obs_index_col is not None:
-        assert obs_index_col in df_current.columns, f'Index column "{obs_index_col}" not found for {file_id}\n{df_current}'
-        df_current = df_current.set_index(obs_index_col)
     if df_previous is None:
         return df_current.rename(
             columns={


### PR DESCRIPTION
Determining which columns are equivalent is done before the index is harmonised, leading to incorrectly duplicated columns