### PR TITLE
Subset masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 05.05.2025 Storage optimisation when subsetting data
 
+PR: https://github.com/HCA-integration/scAtlasTb/pull/233
+
 Subset dataset by only saving coordinates of the entries that are being subset to. This omits saving a new copy of the data for subsets.
 
 **Performance boost:** Massive storage savings when e.g. data is split after a parameter grid search is performed on those splits. This also saves time spent writing the unnecessary copies, and loading a large matrix and subsetting it is sufficiently fast (since data is not fully loaded).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 05.05.2025 Storage optimisation when subsetting data
+
+Subset dataset by only saving coordinates of the entries that are being subset to. This omits saving a new copy of the data for subsets.
+
+**Performance boost:** Massive storage savings when e.g. data is split after a parameter grid search is performed on those splits. This also saves time spent writing the unnecessary copies, and loading a large matrix and subsetting it is sufficiently fast (since data is not fully loaded).
+
+### BREAKING CHANGE
+Zarr files that have been subset via masking, cannot be read by the `anndata.read_zarr`, but instead relies on `utils.read_anndata`, which internally subsets the slots before creating the correct anndata object.
+
 ## 14.12.2023 extend relabel model
 
 Extend the model to allow for merging of existing columns.

--- a/workflow/filter/test/config.yaml
+++ b/workflow/filter/test/config.yaml
@@ -7,7 +7,7 @@ DATASETS:
     input:
       filter: test/input/load_data/harmonize_metadata/Lee2020.zarr
     filter:
-      subset: true
+      subset: false
       dask: true
       backed: true
       remove_by_column:
@@ -30,7 +30,7 @@ DATASETS:
     input:
       filter: test/input/pbmc68k.h5ad
     filter:
-      subset: false
+      subset: true
       remove_by_column:
         phase:
           - G1

--- a/workflow/load_data/rules/filter.smk
+++ b/workflow/load_data/rules/filter.smk
@@ -20,7 +20,7 @@ use rule filter from load_data_filter as load_data_filter_study with:
         remove_by_column=lambda wildcards: config['filter_per_study'][wildcards.study].get('remove_by_column', {}),
         backed=False,
         dask=True,
-        subset=True,
+        subset=False,
     resources:
         mem_mb=get_resource(config,profile='cpu',resource_key='mem_mb'),
 

--- a/workflow/load_data/rules/load_data.smk
+++ b/workflow/load_data/rules/load_data.smk
@@ -58,8 +58,8 @@ rule harmonize_metadata:
         meta=lambda wildcards: unlist_dict(
             get_wildcards(dataset_df, columns=all_but(dataset_df.columns,'subset'), wildcards=wildcards)
         ),
-        backed=False,
-        dask=False,
+        backed=True,
+        dask=True,
     output:
         zarr=directory(out_dir / 'harmonize_metadata' / '{dataset}.zarr'),
         # plot=image_dir / 'harmonize_metadata' / 'counts_sanity--{dataset}.png',

--- a/workflow/load_data/rules/merge.smk
+++ b/workflow/load_data/rules/merge.smk
@@ -14,8 +14,8 @@ use rule merge from load_data as load_data_merge_organ with:
     params:
         dataset=lambda wildcards: wildcards.organ,
         merge_strategy='inner',
-        backed=False, # when backed only, code breaks when var are not the same
-        dask=False,
+        dask=True,
+        backed=True, # when backed only, code breaks when var are not the same
     resources:
         mem_mb=lambda wildcards, attempt: get_resource(config,profile='cpu',resource_key='mem_mb', attempt=attempt, factor=3),
     threads:
@@ -33,8 +33,8 @@ use rule merge from load_data as load_data_merge_organ_filter with:
     params:
         dataset=lambda wildcards: wildcards.organ,
         merge_strategy='inner',
-        backed=False,
-        dask=False,
+        backed=True,
+        dask=True,
     resources:
         mem_mb=lambda wildcards, attempt: get_resource(config,profile='cpu',resource_key='mem_mb', attempt=attempt),
     threads:
@@ -52,8 +52,8 @@ use rule merge from load_data as load_data_merge_subset with:
     params:
         dataset=lambda wildcards: f'{wildcards.organ}-{wildcards.subset}',
         merge_strategy='inner',
-        backed=False,
-        dask=False,
+        backed=True,
+        dask=True,
     resources:
         mem_mb=lambda wildcards, attempt: get_resource(config,profile='cpu',resource_key='mem_mb', attempt=attempt),
         # disk_mb=get_resource(config,profile='cpu',resource_key='disk_mb'),

--- a/workflow/load_data/scripts/harmonize_metadata.py
+++ b/workflow/load_data/scripts/harmonize_metadata.py
@@ -12,7 +12,7 @@ import numpy as np
 from dask import config as da_config
 
 from load_data_utils import SCHEMAS, get_union
-from utils.io import read_anndata, to_memory
+from utils.io import read_anndata, write_zarr
 from utils.misc import ensure_sparse, dask_compute
 
 in_file = snakemake.input.h5ad
@@ -21,8 +21,8 @@ annotation_file = snakemake.input.get('annotation_file')
 out_file = snakemake.output.zarr
 # out_plot = snakemake.output.plot
 
-backed = snakemake.params.get('backed', False)
-dask = snakemake.params.get('dask', False)
+backed = snakemake.params.get('backed', True)
+dask = snakemake.params.get('dask', True)
 meta = snakemake.params.get('meta', {})
 logging.info(f'meta:\n{pformat(meta)}')
 
@@ -44,8 +44,6 @@ for key in list(adata.uns.keys()):
     del adata.uns[key]
 
 # ensure raw counts are kept in .X
-if 'final' not in adata.layers:
-    adata.layers['final'] = adata.X
 adata.X = adata.raw.X if isinstance(adata.raw, ad._core.raw.Raw) else adata.X
 del adata.raw
 
@@ -69,6 +67,7 @@ if annotation_file is not None:
 
     # remove duplicates
     annotation = annotation.drop_duplicates(subset=barcode_column)
+    print(annotation.head(), flush=True)
 
     # set index
     annotation.index = annotation[barcode_column].astype(str)
@@ -127,7 +126,8 @@ for key, value in meta.items():
     adata.obs[key] = value
 
 # save barcodes in separate column
-adata.obs['barcode'] = adata.obs_names
+if 'barcode' not in adata.obs.columns:
+    adata.obs['barcode'] = adata.obs_names
 adata.obs_names = adata.uns['dataset'] + '-' + adata.obs.reset_index(drop=True).index.astype(str)
 
 # schemas translation
@@ -169,4 +169,4 @@ adata.var.index.set_names('feature_id', inplace=True)
 logging.info(f'\033[0;36mwrite\033[0m {out_file}...')
 with da_config.set(num_workers=snakemake.threads):
     adata = dask_compute(adata)
-    adata.write_zarr(out_file)
+    write_zarr(adata, out_file)

--- a/workflow/load_data/test/configs/cellxgene.yaml
+++ b/workflow/load_data/test/configs/cellxgene.yaml
@@ -12,12 +12,12 @@ filter_per_study:
       sample:
         - Schulte-Schrepping_C2P01H_d0
         - Schulte-Schrepping_C2P05F_d0
-        - Schulte-Schrepping_C2P07H_d0
-        - Schulte-Schrepping_C2P10H_d0
-        - Schulte-Schrepping_C2P13F_d0
-        - Schulte-Schrepping_C2P15H_d0
-        - Schulte-Schrepping_C2P16H_d0
-        - Schulte-Schrepping_C2P19H_d0
+        # - Schulte-Schrepping_C2P07H_d0
+        # - Schulte-Schrepping_C2P10H_d0
+        # - Schulte-Schrepping_C2P13F_d0
+        # - Schulte-Schrepping_C2P15H_d0
+        # - Schulte-Schrepping_C2P16H_d0
+        # - Schulte-Schrepping_C2P19H_d0
       donor:
         - C19-CB-0008
       disease:

--- a/workflow/metrics/scripts/prepare.py
+++ b/workflow/metrics/scripts/prepare.py
@@ -29,7 +29,7 @@ neighbor_args = params.get('neighbor_args', {})
 unintegrated_layer = params.get('unintegrated_layer', 'X')
 corrected_layer = params.get('corrected_layer', 'X')
 
-files_to_keep = ['obsm', 'obsp', 'raw', 'uns', 'var']
+files_to_keep = ['raw', 'uns', 'var']
 
 # determine output types
 # default output type is 'full'
@@ -91,9 +91,14 @@ if output_type == 'full':
     adata.obsm['X_emb'] = adata.obsm['X_pca']
     del hvg_matrix
     force_neighbors = True
+    files_to_keep.append('obsm/X_pca')
 elif output_type == 'embed':
     logging.info('Run PCA on embedding...')
     compute_pca(adata, matrix=adata.obsm['X_emb'])
+    files_to_keep.append('obsm/X_pca')
+
+if force_neighbors:
+    files_to_keep.append('obsp')
 
 logging.info(f'Computing neighbors for output type {output_type} force_neighbors={force_neighbors}...')
 compute_neighbors(

--- a/workflow/qc/scripts/autoqc.py
+++ b/workflow/qc/scripts/autoqc.py
@@ -13,6 +13,8 @@ output_file = snakemake.output[0]
 gauss_threshold = snakemake.params['gauss_threshold']
 layer = snakemake.params['layer']
 
+files_to_keep = ['obs', 'uns']
+
 adata = read_anndata(
     input_file,
     X=layer,
@@ -26,12 +28,12 @@ if adata.n_obs == 0:
         columns=adata.obs.columns.tolist() \
             +["n_counts", "n_genes", "percent_mito", "percent_ribo", "percent_hb"]
     )
-    write_zarr_linked(adata, input_file, output_file, files_to_keep=[])
+    write_zarr_linked(adata, input_file, output_file, files_to_keep=files_to_keep)
     exit(0)
 
 print('Calculate QC stats...')
 if 'feature_name' in adata.var.columns:
-    var_names = adata.var['feature_name']
+    var_names = adata.var['feature_name'].astype(str)
 else:
     var_names = adata.var_names
 
@@ -56,5 +58,5 @@ write_zarr_linked(
     adata,
     input_file,
     output_file,
-    files_to_keep=['obs', 'uns']
+    files_to_keep=files_to_keep,
 )

--- a/workflow/split_data/Snakefile
+++ b/workflow/split_data/Snakefile
@@ -10,13 +10,14 @@ from utils.ModuleConfig import ModuleConfig
 mcfg = ModuleConfig(
     module_name='split_data',
     config=config,
-    config_params=['key', 'values', 'backed', 'dask', 'exclude_slots'],
+    config_params=['key', 'values', 'backed', 'dask', 'exclude_slots', 'write_copy'],
     wildcard_names=['key', 'value'],
     rename_config_params={'values': 'value'},
     explode_by=['value'],
     dtypes={
         'backed': 'bool',
         'dask': 'bool',
+        'write_copy': 'bool',
     }
 )
 paramspace = mcfg.get_paramspace()
@@ -46,6 +47,7 @@ rule split:
         backed=lambda wildcards: mcfg.get_from_parameters(wildcards, 'backed'),
         dask=lambda wildcards: mcfg.get_from_parameters(wildcards, 'dask'),
         exclude_slots=lambda wildcards: mcfg.get_from_parameters(wildcards, 'exclude_slots', default=[]),
+        write_copy=lambda wildcards: mcfg.get_from_parameters(wildcards, 'write_copy', default=False),
     resources:
         mem_mb=lambda wildcards, attempt: mcfg.get_resource(profile='cpu',resource_key='mem_mb', attempt=attempt, factor=1),
     threads: 5
@@ -60,6 +62,7 @@ rule link:
     input:
         splits=lambda wildcards: mcfg.get_output_files(rules.split.output.splits, subset_dict=wildcards),
         done=lambda wildcards: mcfg.get_output_files(rules.split.output.done, subset_dict=wildcards),
+        input_file=lambda wildcards: mcfg.get_input_file(wildcards.dataset, wildcards.file_id),
     output:
         zarr=directory(mcfg.out_dir / f'{paramspace.wildcard_pattern}.zarr'),
     localrule: True

--- a/workflow/split_data/test/run_assertions.py
+++ b/workflow/split_data/test/run_assertions.py
@@ -25,6 +25,6 @@ for file in outputs:
         assert 'var' in z
 
     except AssertionError as e:
-        pprint(uns)
+        # pprint(uns.keys())
         print('AssertionError for:', file)
         raise e

--- a/workflow/utils/io.py
+++ b/workflow/utils/io.py
@@ -159,7 +159,7 @@ def read_partial(
     if chunks is None:
         chunks = (stride, -1)
     print_flushed(f'dask: {dask}, backed: {backed}', verbose=verbose)
-    if dask:
+    if dask and verbose:
         print_flushed('chunks:', chunks)
     
     slots = {}
@@ -260,17 +260,17 @@ def _read_slot_dask(
             elem = sparse_dataset(elem)
             return sparse_dataset_as_dask(elem, stride=stride)
         print_flushed(f'Read {slot} as sparse dask array...', verbose=verbose)
-        elem = read_as_dask_array(elem, chunks=chunks)
+        elem = read_as_dask_array(elem, chunks=chunks, verbose=verbose)
         return elem.map_blocks(csr_matrix_int64_indptr, dtype=elem.dtype)
     
     elif iospec.encoding_type in force_sparse_types or force_slot_sparse:
         print_flushed(f'Read {slot} as dask array and convert blocks to csr_matrix...', verbose=verbose)
-        elem = read_as_dask_array(elem, chunks=chunks)
+        elem = read_as_dask_array(elem, chunks=chunks, verbose=verbose)
         return elem.map_blocks(csr_matrix_int64_indptr, dtype=elem.dtype)
     
     elif iospec.encoding_type == "array":
         print_flushed(f'Read {slot} as dask array...', verbose=verbose)
-        return read_as_dask_array(elem, chunks=chunks)
+        return read_as_dask_array(elem, chunks=chunks, verbose=verbose)
     
     return read_elem(elem)
 

--- a/workflow/utils/io.py
+++ b/workflow/utils/io.py
@@ -70,6 +70,7 @@ def read_anndata(
     chunks: [int, tuple] = None,
     stride: int = 200_000,
     verbose: bool = True,
+    dask_slots: list = ['layers', 'raw'],
     **kwargs
 ) -> ad.AnnData:
     """
@@ -115,6 +116,7 @@ def read_anndata(
         chunks=chunks,
         stride=stride,
         verbose=verbose,
+        dask_slots=dask_slots,
         **kwargs
     )
     if not backed and file_type == 'h5py':
@@ -131,6 +133,7 @@ def read_partial(
     stride: int = 1000,
     force_sparse_types: [str, list] = None,
     force_sparse_slots: [str, list] = None,
+    dask_slots: [str, list] = ['layers', 'raw'],
     verbose: bool = False,
     **kwargs
 ) -> ad.AnnData:
@@ -173,8 +176,8 @@ def read_partial(
                     f'{from_slot}/{sub_slot}',
                     force_sparse_types,
                     force_slot_sparse,
-                    backed=backed,
-                    dask=dask,
+                    backed=backed and from_slot in dask_slots,
+                    dask=dask and from_slot in dask_slots,
                     chunks=chunks,
                     stride=stride,
                     verbose=verbose,

--- a/workflow/utils/io.py
+++ b/workflow/utils/io.py
@@ -37,13 +37,23 @@ def get_file_reader(file):
     return func, file_type
 
 
-def check_slot_exists(file, slot):
+def get_store(file, return_file_type=False):
     func, file_type = get_file_reader(file)
-    with func(file, 'r') as f:
-        exists = slot in f
-    return exists
+    try:
+        store = func(file, 'r')
+    except zarr.errors.PathNotFoundError as e:
+        raise FileNotFoundError(f'Cannot read file {file}') from e
+    if return_file_type:
+        return store, file_type
+    return store
 
 
+def check_slot_exists(file, slot):
+    store = get_store(file)
+    return slot in store
+
+
+# TODO: deprecate
 def to_memory(matrix):
     if isinstance(matrix, (ad.experimental.CSRDataset, ad.experimental.CSCDataset)):
         print_flushed('Convert to memory...')

--- a/workflow/utils/sparse_dask.py
+++ b/workflow/utils/sparse_dask.py
@@ -11,14 +11,16 @@ import anndata as ad
 from anndata.experimental import read_elem, sparse_dataset
 
 
-def read_as_dask_array(elem, chunks=('auto', -1)):
+def read_as_dask_array(elem, chunks=('auto', -1), verbose=True):
     if isinstance(elem, zarr.storage.BaseStore):
-        print('Read dask array from zarr directly', flush=True)
+        if verbose:
+            print('Read dask array from zarr directly', flush=True)
         return da.from_zarr(elem, chunks=chunks)
-    print('Read and convert to dask array', flush=True)
+    if verbose:
+        print('Read and convert to dask array', flush=True)
     elem = read_elem(elem)
     if np.min(elem.shape) == 0:
-        chunks = 'auto'
+        chunks = elem.shape
     return da.from_array(elem, chunks=chunks)
 
 

--- a/workflow/utils/subset_slots.py
+++ b/workflow/utils/subset_slots.py
@@ -181,60 +181,7 @@ def remove_mask_file(mask_file, link_slot):
     remove_path(mask_file, remove_file=True)
     
 
-# def set_mask_old(mask, out_dir):
-#     obs_mask, var_mask = mask
-#     mask_dir = out_dir / 'mask'
-    
-#     if mask_dir.exists():
-    
-#         # update mask
-#         obs_mask_old = np.load(out_dir / 'mask' / 'obs_mask.npy')
-#         var_mask_old = np.load(out_dir / 'mask' / 'var_mask.npy')
-        
-#         assert obs_mask_old[obs_mask_old].shape == obs_mask.shape, \
-#             f'{obs_mask_old[obs_mask_old].shape} != {obs_mask.shape}'
-#         assert var_mask_old[var_mask_old].shape == var_mask.shape, \
-#             f'{var_mask_old[var_mask_old].shape} != {var_mask.shape}'
-        
-#         # Update old masks
-#         obs_mask_old[obs_mask_old] &= obs_mask
-#         obs_mask = obs_mask_old
-        
-#         var_mask_old[var_mask_old] &= var_mask
-#         var_mask = var_mask_old
-
-#         # remove pre-existing symlink
-#         mask_dir.unlink()
-    
-#     # create new directory
-#     mask_dir.mkdir()
-#     np.save(mask_dir / 'obs_mask.npy', obs_mask)
-#     np.save(mask_dir / 'var_mask.npy', var_mask)
-
-
 ## Functions for subsetting slots when reading them
-
-# def subset_slots(slots, mask_dir, chunks, verbose=True):
-#     for slot_name, slot in tqdm(slots.items(), desc='subset slots', disable=not verbose):
-#         if isinstance(slot, dict) and slot != 'uns':
-#             for key, value in slot.items():
-#                 slot = subset_slot(
-#                     slot_name=slot_name,
-#                     slot=value,
-#                     mask_dir=mask_dir,
-#                     chunks=chunks
-#                 )
-#                 slots[slot_name][key] = slot
-#         else:
-#             slot = subset_slot(
-#                 slot_name=slot_name,
-#                 slot=slot,
-#                 mask_dir=mask_dir,
-#                 chunks=chunks
-#             )
-#             slots[slot_name] = slot
-#     return slots
-
 
 def subset_slot(slot_name, slot, mask_dir, chunks=('auto', -1)):
     if slot is None or not mask_dir.exists():
@@ -293,7 +240,7 @@ def _subset_matrix(slot, mask_dir):
     obs_mask_file = mask_dir / 'obs.npy'
     var_mask_file = mask_dir / 'var.npy'
     if not obs_mask_file.exists() or not var_mask_file.exists():
-        return slot # _subset_slot_old(slot_name, slot, mask_dir, chunks)
+        return slot
     
     obs_mask = np.load(obs_mask_file)
     var_mask = np.load(var_mask_file)
@@ -305,7 +252,7 @@ def _subset_slot(slot_name, slot, mask_dir):
     mask_file = mask_dir / 'mask.npy'
     
     if not mask_file.exists():
-        return slot # _subset_slot_old(slot_name, slot, mask_dir, chunks)
+        return slot
     
     mask = np.load(mask_file)
     
@@ -314,38 +261,3 @@ def _subset_slot(slot_name, slot, mask_dir):
         return slot[mask, :][:, mask].copy()
     
     return slot[mask].copy()
-
-
-# def _subset_slot_old(slot_name, slot, mask_dir, chunks):
-#     obs_mask = np.load(mask_dir / 'obs_mask.npy')
-#     var_mask = np.load(mask_dir / 'var_mask.npy')
-    
-#     n_obs = len(obs_mask)
-#     n_vars = len(var_mask)
-    
-#     if slot_name in ['X', 'layers', 'raw']:
-#         if slot.shape[0] == n_obs:
-#             slot = slot[obs_mask, :]
-#         if slot.shape[1] == n_vars:
-#             slot = slot[:, var_mask]
-#         if isinstance(slot, da.Array):
-#             return slot.copy().rechunk(chunks)
-#         return slot.copy()
-    
-#     if slot_name.startswith('obs') and slot.shape[0] == n_obs:
-#         if slot_name == 'obsp':
-#             slot = slot[obs_mask, :][:, obs_mask].copy()
-#         slot = slot[obs_mask].copy()
-#         if slot_name == 'obs':
-#             for col in slot.columns:
-#                 if slot[col].dtype.name == 'category':
-#                     slot[col] = slot[col].cat.remove_unused_categories()
-#         return slot
-    
-#     if slot_name.startswith('var') and slot.shape[0] == n_vars:
-#         if slot_name == 'varp':
-#             return slot[var_mask, :][:, var_mask].copy()
-#         return slot[var_mask].copy()
-    
-#     return slot
-

--- a/workflow/utils/subset_slots.py
+++ b/workflow/utils/subset_slots.py
@@ -1,0 +1,351 @@
+from pathlib import Path
+import shutil
+from tqdm import tqdm
+import numpy as np
+import pandas as pd
+from dask import array as da
+
+
+## Writing subset masks
+def set_mask_per_slot(slot, mask, out_dir, in_slot=None, in_dir=None):
+    
+    def _call_function_per_slot(func, path, *args, **kwargs):
+        if path.is_dir() and (path / '.zattrs').exists():
+            func(*args, **kwargs)
+    
+    link_slot = in_slot is not None
+    
+    if slot == 'uns':
+        # do not set mask for uns slots
+        return
+    
+    out_dir = Path(out_dir)
+    mask_dir = out_dir / 'subset_mask'
+    mask_dir = init_mask_dir(mask_dir, slot, in_slot, in_dir)
+    
+    if mask is not None:
+        if slot.startswith('obs'):
+            mask = mask[0]
+        elif slot.startswith('var'):
+            mask = mask[1]
+    
+    match slot:
+        
+        case _ if slot == 'X' or slot.startswith('layers/'):
+            save_feature_matrix_mask(
+                mask_dir=mask_dir,
+                mask=mask,
+                link_slot=link_slot
+            )
+
+        case 'obs' | 'var':
+            save_slot_mask(
+                mask_dir=mask_dir,
+                mask=mask,
+                link_slot=link_slot
+            )
+        
+        case 'layers':
+            for path in (out_dir / slot).iterdir():
+                _call_function_per_slot(
+                    func=save_feature_matrix_mask,
+                    path=path,
+                    mask_dir=mask_dir / path.name,
+                    mask=mask,
+                    link_slot=link_slot,
+                )
+        
+        case 'obsp' | 'obsm' | 'varp' | 'varm':
+            for path in (out_dir / slot).iterdir():
+                _call_function_per_slot(
+                    save_slot_mask,
+                    path=path,
+                    mask_dir=mask_dir / path.name,
+                    mask=mask,
+                    link_slot=link_slot,
+                )
+        
+        case 'raw':
+            if not mask_dir.exists():
+                return
+            for path in mask_dir.iterdir():
+                # recursive call for subdirectories
+                _call_function_per_slot(
+                    set_mask_per_slot,
+                    path=path,
+                    slot=slot,
+                    mask=mask,
+                    out_dir=out_dir / slot,
+                    in_slot=in_slot,
+                )
+
+        case _:
+            print(f'Unknown slot: {slot}', flush=True)
+
+
+def remove_path(path, remove_file=False):
+    if path.is_symlink():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+    elif path.is_file() and remove_file:
+        path.unlink()
+    
+
+def init_mask_dir(mask_dir, slot, in_slot, in_dir):
+    """
+    Create if missing or copy files from symlinked directory.
+    """
+    if not mask_dir.exists():
+        mask_dir.mkdir(parents=True)
+    elif mask_dir.is_symlink():
+        link_dir = mask_dir.resolve()
+        mask_dir.unlink()
+        # Copy the folder from the original location
+        shutil.copytree(link_dir, mask_dir)
+    
+    mask_dir_slot = mask_dir / slot
+    
+    if in_slot is not None:
+        remove_path(mask_dir_slot)
+        in_dir = (in_dir / 'subset_mask' / in_slot).resolve()
+        if in_dir.exists():
+            # Copy the folder from the original location
+            shutil.copytree(in_dir, mask_dir_slot)
+    
+    return mask_dir_slot
+
+
+def save_feature_matrix_mask(mask_dir, mask, link_slot):
+    """
+    Save the subset mask for the feature matrices e.g. from X, raw/X or layers/*
+    """
+    obs_mask_file = mask_dir  / 'obs.npy'
+    var_mask_file = mask_dir  / 'var.npy'
+    
+    if mask is None:
+        # remove any pre-existing mask files, since slot is being overwritten with correct shape
+        # -> no subset mask required
+        remove_mask_file(mask_dir, link_slot)
+        return
+    
+    if not mask_dir.exists():
+        mask_dir.mkdir(parents=True)
+    
+    if link_slot:
+        # update subset masks
+        mask = (
+            update_mask(obs_mask_file, mask[0]),
+            update_mask(var_mask_file, mask[1])
+        )
+    
+    np.save(obs_mask_file, mask[0])
+    np.save(var_mask_file, mask[1])
+
+
+def save_slot_mask(mask_dir, mask, link_slot):
+     
+    if mask is None:
+        # # remove any pre-existing mask file, since slot is being overwritten with correct shape
+        # # -> no subset mask required
+        remove_mask_file(mask_dir, link_slot)
+        return
+
+    mask_file = mask_dir / 'mask.npy'
+    mask_dir.mkdir(parents=True, exist_ok=True)
+    if mask_file.exists() and link_slot:
+        # update mask for linked mask_file slot
+        mask = update_mask(mask_file, mask)
+    
+    np.save(mask_file, mask)
+
+
+def update_mask(mask_file, mask):
+    """
+    Update the existing mask with the new mask, assuming the new mask is a subset of the old mask.
+    """
+    if not mask_file.exists():
+        return mask
+    
+    mask_old = np.load(mask_file)
+    assert mask_old[mask_old].shape == mask.shape, \
+        f'{mask_old[mask_old].shape} != {mask.shape}\n {mask_file}'
+    
+    mask_old[mask_old] &= mask
+    return mask_old
+
+
+def remove_mask_file(mask_file, link_slot):
+    if link_slot:
+        return
+    remove_path(mask_file, remove_file=True)
+    
+
+# def set_mask_old(mask, out_dir):
+#     obs_mask, var_mask = mask
+#     mask_dir = out_dir / 'mask'
+    
+#     if mask_dir.exists():
+    
+#         # update mask
+#         obs_mask_old = np.load(out_dir / 'mask' / 'obs_mask.npy')
+#         var_mask_old = np.load(out_dir / 'mask' / 'var_mask.npy')
+        
+#         assert obs_mask_old[obs_mask_old].shape == obs_mask.shape, \
+#             f'{obs_mask_old[obs_mask_old].shape} != {obs_mask.shape}'
+#         assert var_mask_old[var_mask_old].shape == var_mask.shape, \
+#             f'{var_mask_old[var_mask_old].shape} != {var_mask.shape}'
+        
+#         # Update old masks
+#         obs_mask_old[obs_mask_old] &= obs_mask
+#         obs_mask = obs_mask_old
+        
+#         var_mask_old[var_mask_old] &= var_mask
+#         var_mask = var_mask_old
+
+#         # remove pre-existing symlink
+#         mask_dir.unlink()
+    
+#     # create new directory
+#     mask_dir.mkdir()
+#     np.save(mask_dir / 'obs_mask.npy', obs_mask)
+#     np.save(mask_dir / 'var_mask.npy', var_mask)
+
+
+## Functions for subsetting slots when reading them
+
+# def subset_slots(slots, mask_dir, chunks, verbose=True):
+#     for slot_name, slot in tqdm(slots.items(), desc='subset slots', disable=not verbose):
+#         if isinstance(slot, dict) and slot != 'uns':
+#             for key, value in slot.items():
+#                 slot = subset_slot(
+#                     slot_name=slot_name,
+#                     slot=value,
+#                     mask_dir=mask_dir,
+#                     chunks=chunks
+#                 )
+#                 slots[slot_name][key] = slot
+#         else:
+#             slot = subset_slot(
+#                 slot_name=slot_name,
+#                 slot=slot,
+#                 mask_dir=mask_dir,
+#                 chunks=chunks
+#             )
+#             slots[slot_name] = slot
+#     return slots
+
+
+def subset_slot(slot_name, slot, mask_dir, chunks=('auto', -1)):
+    if slot is None or not mask_dir.exists():
+        return slot
+    
+    if isinstance(slot, dict):
+        slot = {
+            key: subset_slot(
+                slot_name=f'{slot_name}/{key}',
+                slot=value,
+                mask_dir=mask_dir / key,
+                chunks=chunks
+            ) for key, value in slot.items()
+        }
+        return slot
+    
+    elif slot_name == 'raw':
+        # dead code
+        mask_dir = mask_dir / 'raw'
+        for slot_name in ALL_SLOTS.items():
+            slot.X = _subset_matrix(slot.X, mask_dir)
+            slot.var = _subset_slot(slot_name, slot.var, mask_dir)
+            slot.varm = _subset_slot(slot_name, slot.varm, mask_dir)
+    
+    elif slot_name.startswith('raw/'):
+        slot_name = slot_name.split('/', 1)[-1]
+        mask_dir = mask_dir.parent / 'raw' / mask_dir.name
+        slot = subset_slot(
+            slot_name=slot_name,
+            slot=slot,
+            mask_dir=mask_dir
+        )
+    
+    elif slot_name == 'X':
+        slot = _subset_matrix(slot, mask_dir / slot_name)
+
+    elif slot_name.startswith('layers/'):
+        slot = _subset_matrix(slot, mask_dir / slot_name)
+    
+    elif slot_name != 'uns':
+        slot = _subset_slot(slot_name, slot, mask_dir / slot_name)
+
+    if isinstance(slot, da.Array):
+        slot = slot.rechunk(chunks=chunks)
+    
+    if isinstance(slot, pd.DataFrame):
+        for col in slot.columns:
+            if slot[col].dtype.name != 'category':
+                continue
+            slot[col] = slot[col].cat.remove_unused_categories()
+
+    return slot
+
+
+def _subset_matrix(slot, mask_dir):
+    obs_mask_file = mask_dir / 'obs.npy'
+    var_mask_file = mask_dir / 'var.npy'
+    if not obs_mask_file.exists() or not var_mask_file.exists():
+        return slot # _subset_slot_old(slot_name, slot, mask_dir, chunks)
+    
+    obs_mask = np.load(obs_mask_file)
+    var_mask = np.load(var_mask_file)
+    
+    return slot[obs_mask, :][:, var_mask].copy()
+
+
+def _subset_slot(slot_name, slot, mask_dir):
+    mask_file = mask_dir / 'mask.npy'
+    
+    if not mask_file.exists():
+        return slot # _subset_slot_old(slot_name, slot, mask_dir, chunks)
+    
+    mask = np.load(mask_file)
+    
+    if slot_name.startswith('obsp/') or slot_name.startswith('varp/'):
+        # subset in both dimensions
+        return slot[mask, :][:, mask].copy()
+    
+    return slot[mask].copy()
+
+
+# def _subset_slot_old(slot_name, slot, mask_dir, chunks):
+#     obs_mask = np.load(mask_dir / 'obs_mask.npy')
+#     var_mask = np.load(mask_dir / 'var_mask.npy')
+    
+#     n_obs = len(obs_mask)
+#     n_vars = len(var_mask)
+    
+#     if slot_name in ['X', 'layers', 'raw']:
+#         if slot.shape[0] == n_obs:
+#             slot = slot[obs_mask, :]
+#         if slot.shape[1] == n_vars:
+#             slot = slot[:, var_mask]
+#         if isinstance(slot, da.Array):
+#             return slot.copy().rechunk(chunks)
+#         return slot.copy()
+    
+#     if slot_name.startswith('obs') and slot.shape[0] == n_obs:
+#         if slot_name == 'obsp':
+#             slot = slot[obs_mask, :][:, obs_mask].copy()
+#         slot = slot[obs_mask].copy()
+#         if slot_name == 'obs':
+#             for col in slot.columns:
+#                 if slot[col].dtype.name == 'category':
+#                     slot[col] = slot[col].cat.remove_unused_categories()
+#         return slot
+    
+#     if slot_name.startswith('var') and slot.shape[0] == n_vars:
+#         if slot_name == 'varp':
+#             return slot[var_mask, :][:, var_mask].copy()
+#         return slot[var_mask].copy()
+    
+#     return slot
+


### PR DESCRIPTION
Subset dataset by only saving coordinates of the entries that are being subset to. This omits saving a new copy of the data for subsets.

**Performance boost:** Massive storage savings when e.g. data is split after a parameter grid search is performed on those splits. This also saves time spent writing the unnecessary copies, and loading a large matrix and subsetting it is sufficiently fast (since data is not fully loaded).

### BREAKING CHANGE
Zarr files that have been subset via masking, cannot be read by the `anndata.read_zarr`, but instead relies on `utils.read_anndata`, which internally subsets the slots before creating the correct anndata object.