### PR TITLE
Fix metrics cluster config

### DIFF
--- a/workflow/clustering/scripts/clustering.py
+++ b/workflow/clustering/scripts/clustering.py
@@ -108,10 +108,10 @@ max_cluster_factor = snakemake.params.get('max_cluster_factor', 50)
 
 # set parameters for clustering
 cluster_key = f'{algorithm}_{resolution}_{level}'
-kwargs = dict(
+kwargs = snakemake.params.get('clustering_args', {}) | dict(
     resolution=resolution,
     key_added=cluster_key,
-) | snakemake.params.get('clustering_args', {})
+)
 cpu_kwargs = dict(flavor='igraph')
 if algorithm == 'leiden':
     cpu_kwargs |= dict(n_iterations=2)

--- a/workflow/metrics/Snakefile
+++ b/workflow/metrics/Snakefile
@@ -31,6 +31,7 @@ mcfg = MetricsConfig(
         'corrected',
         'raw_counts',
         'overwrite_file_id',
+        'clustering',
         'cluster_algorithm',
         'covariates',
         'gene_sets',

--- a/workflow/metrics/params.tsv
+++ b/workflow/metrics/params.tsv
@@ -1,4 +1,4 @@
-metric	metric_type	output_types	input_type	comparison	clustering	use_covariate	use_gene_set	env	resources	threads
+metric	metric_type	output_types	input_type	comparison	needs_clustering	use_covariate	use_gene_set	env	resources	threads
 asw_batch	batch_correction	full,embed	embed	False	False	False	False	scib_accel	cpu	1
 graph_connectivity	batch_correction	full,embed,knn	knn	False	False	False	False	scib	cpu	1
 ilisi	batch_correction	full,embed,knn	knn	False	False	False	False	scib	cpu	1

--- a/workflow/metrics/rules/metrics.smk
+++ b/workflow/metrics/rules/metrics.smk
@@ -7,7 +7,7 @@ class MetricNotDefinedError(RuntimeError):
 
 
 def get_metric_input(wildcards):
-    if mcfg.get_from_parameters(wildcards, 'clustering', default=False):
+    if mcfg.get_from_parameters(wildcards, 'needs_clustering', default=False):
         return rules.metrics_cluster_collect.output.zarr
     if mcfg.get_from_parameters(wildcards, 'use_gene_set', default=False):
         return rules.score_genes.output.zarr

--- a/workflow/metrics/test/config.yaml
+++ b/workflow/metrics/test/config.yaml
@@ -33,7 +33,7 @@ defaults:
       - kbet_pg
   datasets:
     - test_metrics
-    - test_no_name
+    - test_clustering_metrics
     - test_integration
     - scib_metrics
     - morans_i
@@ -51,14 +51,21 @@ DATASETS:
       batch: louvain
       overwrite_file_id: true
 
-    test_no_name:
-      input:
-        metrics: test/input/pbmc68k.h5ad
+  test_clustering_metrics:
+    input:
+      metrics: test/input/pbmc68k.h5ad
+    metrics:
+      label: bulk_labels
+      batch: batch
+      clustering:
+        kwargs:
+          random_state: 42
+        overwrite: true
       metrics:
-        label: bulk_labels
-        batch: louvain
-        metrics:
-          - nmi
+        - nmi
+        - ari
+        - isolated_label_f1
+        - graph_connectivity
   
   test_integration:
     input:
@@ -69,8 +76,8 @@ DATASETS:
         bbknn: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~bbknn--hyperparams~25cb428a38--label~None--output_type~knn.zarr
         harmony: test/input/integration/dataset~harmony/file_id~3bd5f9cfa3/batch~batch/var_mask~highly_variable/method~harmonypy--hyperparams~a494363475--label~None--output_type~embed.zarr
         # scanorama_full: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~scanorama--hyperparams~a90b47ca49--label~None--output_type~full.zarr
-        scanorama_embed: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~scanorama--hyperparams~a90b47ca49--label~None--output_type~embed.zarr
-        scvi: test/input/integration/dataset~scvi_tools/file_id~orig/batch~batch/var_mask~highly_variable/method~scvi--hyperparams~dbed8671e3--label~None--output_type~embed.zarr
+        # scanorama_embed: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~scanorama--hyperparams~a90b47ca49--label~None--output_type~embed.zarr
+        scvi: test/input/integration/dataset~scvi_tools/file_id~orig/batch~batch/var_mask~highly_variable/method~scvi--hyperparams~9f3f32149c--label~None--output_type~embed.zarr
     metrics:
       unintegrated: layers/normcounts
       raw_counts: layers/counts


### PR DESCRIPTION
Cluster config for metrics prepare rule was throwing an error due to duplicate use of `clustering` parameter.
The fix involves adding an `needs_clustering` parameter per metric, as well as a `clustering` parameter in the user config to configure clustering parameters.