### PR TITLE
Metrics: optimise prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 02.04.2026 Metrics prepare optimisation
+
+PR: https://github.com/HCA-integration/scAtlasTb/pull/361
+
+Metrics module preparation was optimized to reduce memory and I/O overhead and avoid unnecessary recomputation.
+
+- `prepare_all` now aggregates dedicated subtargets (`pca_all`, `score_genes_all`, `cluster_all`) instead of forcing all heavy preparation steps for every dataset.
+- Clustering is skipped automatically for clustering-based metrics when `clustering.precomputed_key` is set.
+- Prepared AnnData now keeps only required embeddings in `.obsm` (`X_pca`, `X_emb`) to reduce output size.
+- Gene-score random permutations are precomputed once and reused across gene sets in `score_genes`, reducing repeated work.
+
 ## 05.05.2025 Storage optimisation when subsetting data
 
 PR: https://github.com/HCA-integration/scAtlasTb/pull/233

--- a/workflow/metrics/README.md
+++ b/workflow/metrics/README.md
@@ -28,10 +28,10 @@ Configure the module under your dataset key using the `metrics` section. Common 
 - `raw_counts`: slot for raw (unnormalised) counts, only needed by metrics that use gene sets
 - `var_mask`: `.var` mask name to subset features (default `highly_variable`)
 - `recompute_neighbors`: whether to recompute neighbors even if they exist in the AnnData object (default `false`). Will only be recomputed for non kNN outputs
-- `clustering`: optional args for cluster-based metrics; supports `kwargs` and `overwrite` (see `clustering` module for more details)
+- `clustering`: optional args for cluster-based metrics; supports `kwargs`, `overwrite`, and `precomputed_key` (see `clustering` module for more details)
 - `gene_sets`: optional gene sets (dict of gene set name and gene list OR str with comma-separated keys of gene set mapping in `MARKER_GENES`) for gene-based metrics
 - `covariates`: optional covariates (str or list) used by Moran's I and PC_regression metric
-- `n_permutations`, `n_quantiles`: settings for gene-scoring utilities
+- `gene_score`: optional settings for gene-scoring utilities. Supports `n_permutations` and `n_quantiles`
 - `weight_batch`: weight in [0, 1] of aggregated batch score used in funkyheatmap. The aggregated bio score gets a weight of 1 - `weight_batch`
 - `metrics`: list of metric names to compute; must exist in `params.tsv`
 
@@ -60,6 +60,9 @@ DATASETS:
       label: bulk_labels  # cell type label
       batch: batch
       output_type: full  # will use .X as representation for metrics
+      gene_score:
+        n_permutations: 20
+        n_quantiles: 5
       metrics:  # list of metrics to be computed
         - nmi
         - ari
@@ -95,6 +98,39 @@ The different `output_type` options are:
 
 The `gene_sets` parameters is only needed by the `morans_i_genes` and `pcr_genes` metrics.
 If none of these metrics are needed, you also don't need to configure `gene_sets`.
+
+You can optionally tune gene-score preparation with:
+
+```yaml
+...
+
+DATASETS:
+  ...
+    metrics:
+      ...
+      gene_score:
+        n_permutations: 50
+        n_quantiles: 5
+```
+
+### Precomputed clustering labels
+
+For clustering-based metrics (e.g. `nmi`, `ari`, `isolated_label_f1`), you can skip the clustering prepare step and use an existing obs column instead:
+
+```yaml
+...
+
+DATASETS:
+  ...
+    metrics:
+      ...
+      clustering:
+        precomputed_key: bulk_labels
+      metrics:
+        - nmi
+        - ari
+        - graph_connectivity
+```
 
 ```yaml
 ...

--- a/workflow/metrics/Snakefile
+++ b/workflow/metrics/Snakefile
@@ -38,10 +38,7 @@ mcfg = MetricsConfig(
         'clustering',
         'covariates',
         'gene_sets',
-        'n_permutations',
-        'n_quantiles',
-        'weight_batch',
-        'overwrite_file_id',
+        'gene_score',
     ],
     # wildcard_names=['label', 'batch'],
     rename_config_params={

--- a/workflow/metrics/rules/metrics.smk
+++ b/workflow/metrics/rules/metrics.smk
@@ -8,7 +8,8 @@ class MetricNotDefinedError(RuntimeError):
 
 def get_metric_input(wildcards):
     files = dict(zarr=rules.prepare.output.zarr)
-    if mcfg.get_from_parameters(wildcards, 'needs_clustering', default=False):
+    if mcfg.get_from_parameters(wildcards, 'needs_clustering', default=False) and \
+       not mcfg.get_from_parameters(wildcards, 'clustering', default={}).get('precomputed_key'):
         files['zarr'] = rules.metrics_cluster_collect.output.zarr
     if mcfg.get_from_parameters(wildcards, 'use_gene_set', default=False):
         files['zarr'] = rules.score_genes.output.zarr
@@ -52,7 +53,7 @@ rule run:
         metric_type=lambda wildcards: mcfg.get_from_parameters(wildcards, 'metric_type', default=MetricNotDefinedError(wildcards)),
         allowed_output_types=lambda wildcards: mcfg.get_from_parameters(wildcards, 'allowed_output_types', default=MetricNotDefinedError(wildcards)),
         input_type=lambda wildcards: mcfg.get_from_parameters(wildcards, 'input_type', default=MetricNotDefinedError(wildcards)),
-        cluster_key=lambda wildcards: mcfg.get_from_parameters(wildcards, 'clustering', default={}).get('algorithm', 'leiden'),
+        clustering=lambda wildcards: mcfg.get_from_parameters(wildcards, 'clustering', default={}),
         use_covariate=lambda wildcards: mcfg.get_from_parameters(wildcards, 'use_covariate', default=False),
         use_gene_set=lambda wildcards: mcfg.get_from_parameters(wildcards, 'use_gene_set', default=False),
         covariates=lambda wildcards: mcfg.get_from_parameters(wildcards, 'covariate', default=[]),

--- a/workflow/metrics/rules/prepare.smk
+++ b/workflow/metrics/rules/prepare.smk
@@ -46,16 +46,14 @@ use rule pca from preprocessing as metrics_pca with:
         mem_mb=lambda w, attempt: mcfg.get_resource(resource_key='mem_mb', profile='gpu', attempt=attempt),
 
 
-rule prepare_all:
+rule pca_all:
     input:
-        prepare=mcfg.get_output_files(rules.prepare.output),
         pca=[
             mcfg.get_output_files(rules.metrics_pca.output, subset_dict=dict(dataset=dataset))
             for dataset in mcfg.get_datasets()
             if sum(mcfg.get_from_parameters(dict(dataset=dataset), 'comparison', single_value=False)) > 0
-        ],
+        ]
     localrule: True
-
 
 # Clustering for cluster-based metrics
 
@@ -107,7 +105,12 @@ use rule merge from clustering as metrics_cluster_collect with:
 
 rule cluster_all:
     input:
-        mcfg.get_output_files(rules.metrics_cluster_collect.output)
+        clusters=[
+            mcfg.get_output_files(rules.metrics_cluster_collect.output, subset_dict=dict(dataset=dataset))
+            for dataset in mcfg.get_datasets()
+            if sum(mcfg.get_from_parameters(dict(dataset=dataset), 'needs_clustering', single_value=False)) > 0
+            and not mcfg.get_from_parameters(dict(dataset=dataset), 'clustering', default={}).get('precomputed_key')
+        ]
     localrule: True
 
 
@@ -137,5 +140,19 @@ rule score_genes:
 
 
 rule score_genes_all:
-    input: mcfg.get_output_files(rules.score_genes.output)
+    input:
+        gene_scores=[
+            mcfg.get_output_files(rules.score_genes.output, subset_dict=dict(dataset=dataset))
+            for dataset in mcfg.get_datasets()
+            if sum(mcfg.get_from_parameters(dict(dataset=dataset), 'use_gene_set', single_value=False)) > 0
+        ]
+    localrule: True
+
+
+rule prepare_all:
+    input:
+        prepare=mcfg.get_output_files(rules.prepare.output),
+        pca=rules.pca_all.input,
+        gene_scores=rules.score_genes_all.input,
+        clusters=rules.cluster_all.input,
     localrule: True

--- a/workflow/metrics/rules/prepare.smk
+++ b/workflow/metrics/rules/prepare.smk
@@ -123,11 +123,10 @@ rule score_genes:
         zarr=directory(mcfg.out_dir / 'prepare' / paramspace.wildcard_pattern / 'gene_scores.zarr'),
     params:
         unintegrated_layer=lambda wildcards: mcfg.get_from_parameters(wildcards, 'unintegrated', default='X'),
-        raw_counts_layer=lambda wildcards: mcfg.get_from_parameters(wildcards, 'raw_counts', default=None),
         var_mask=lambda wildcards: mcfg.get_from_parameters(wildcards, 'var_mask', default='highly_variable'),
         gene_sets=lambda wildcards: mcfg.get_gene_sets(wildcards.dataset),
-        n_permutations=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_permutations', default=20),
-        n_quantiles=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_quantiles', default=5),
+        n_permutations=lambda wildcards: mcfg.get_from_parameters(wildcards, 'gene_score', default={}).get('n_permutations', 20),
+        n_quantiles=lambda wildcards: mcfg.get_from_parameters(wildcards, 'gene_score', default={}).get('n_quantiles', 5),
     conda:
         get_env(config, 'scanpy', gpu_env='rapids_singlecell')
     resources:

--- a/workflow/metrics/scripts/metrics/ari.py
+++ b/workflow/metrics/scripts/metrics/ari.py
@@ -3,7 +3,7 @@ import scanpy as sc
 from .utils import select_neighbors, rename_categories, scanpy_to_neighborsresults
 
 
-def ari(adata, output_type, batch_key, label_key, cluster_key, **kwargs):
+def ari(adata, output_type, batch_key, label_key, cluster_keys, **kwargs):
     import scib
 
     adata = select_neighbors(adata, output_type)

--- a/workflow/metrics/scripts/metrics/isolated_labels.py
+++ b/workflow/metrics/scripts/metrics/isolated_labels.py
@@ -2,12 +2,38 @@ import numpy as np
 from .utils import select_neighbors
 
 
-def isolated_label_f1(adata, output_type, batch_key, label_key, cluster_key, **kwargs):
+def replace_last(source_string, replace_what, replace_with, cluster_key='leiden'):
+    """
+    Helper function for parsing clustering columns
+    adapted from
+    https://stackoverflow.com/questions/3675318/how-to-replace-some-characters-from-the-end-of-a-string/3675423#3675423
+    """
+    if not source_string.startswith(cluster_key):
+        return source_string
+    if not source_string.endswith(replace_what):
+        return source_string + '_orig'
+    head, _sep, tail = source_string.rpartition(replace_what)
+    return head + replace_with + tail
+
+
+def isolated_label_f1(adata, output_type, batch_key, label_key, cluster_keys, **kwargs):
     import scib
 
     adata = select_neighbors(adata, output_type)
+    
+    # rename cluster columns to expected format
+    cluster_rename_map = {col: replace_last(col, '_1', '') for col in cluster_keys}
+    adata.obs.rename(columns=cluster_rename_map, inplace=True)
+    
+    if any('leiden' in key for key in cluster_keys):
+        cluster_key = 'leiden'
+    elif any('louvain' in key for key in cluster_keys):
+        cluster_key = 'louvain'
+    else:
+        raise NotImplementedError(f'No leiden or louvain cluster key found in {cluster_keys}')
+
     return scib.me.isolated_labels_f1(
-        adata[adata.obs[label_key].notna()],
+        adata[adata.obs[label_key].notna()].copy(),
         label_key=label_key,
         batch_key=batch_key,
         cluster_key=cluster_key,

--- a/workflow/metrics/scripts/metrics/isolated_labels.py
+++ b/workflow/metrics/scripts/metrics/isolated_labels.py
@@ -11,7 +11,7 @@ def replace_last(source_string, replace_what, replace_with, cluster_key='leiden'
     if not source_string.startswith(cluster_key):
         return source_string
     if not source_string.endswith(replace_what):
-        return source_string + '_orig'
+        return source_string
     head, _sep, tail = source_string.rpartition(replace_what)
     return head + replace_with + tail
 

--- a/workflow/metrics/scripts/metrics/morans_i.py
+++ b/workflow/metrics/scripts/metrics/morans_i.py
@@ -132,7 +132,7 @@ def morans_i_genes(adata, output_type, gene_set, **kwargs):
 
 def morans_i_genescore(adata, output_type, gene_set, use_random_gene_score=False, **kwargs):
     
-    metric = "M's I gene score"
+    metric = "M's I gs"
     metric_names = []
     scores = []
     
@@ -146,7 +146,7 @@ def morans_i_genescore(adata, output_type, gene_set, use_random_gene_score=False
         score = _morans_i(adata, covariate=gene_score_name)
 
         if use_random_gene_score:
-            random_gene_score_name = f'random_gene_scores:{len(gene_list)}'
+            random_gene_score_name = 'random_gene_scores'
             raise NotImplementedError("The 'use_random_gene_score' option is not yet implemented.")
             #     raise ValueError(f'Gene score {random_gene_score_name} not found in adata.obsm')
 

--- a/workflow/metrics/scripts/metrics/nmi.py
+++ b/workflow/metrics/scripts/metrics/nmi.py
@@ -3,16 +3,30 @@ import scanpy as sc
 from .utils import select_neighbors, rename_categories, scanpy_to_neighborsresults
 
 
-def nmi(adata, output_type, batch_key, label_key, cluster_key, **kwargs):
+def nmi(adata, output_type, batch_key, label_key, cluster_keys, **kwargs):
     import scib
 
     adata = select_neighbors(adata, output_type)
-    scib.cl.cluster_optimal_resolution(
+    adata = adata[adata.obs[label_key].notna()].copy()
+    # scib.cl.cluster_optimal_resolution(
+    #     adata=adata,
+    #     label_key=label_key,
+    #     cluster_key=cluster_key,
+    #     metric=scib.me.nmi,
+    #     use_rep=None,
+    # )
+    cluster_key = cluster_keys[0]
+    nmi_max = 0
+    for col in cluster_keys:
+        nmi = scib.me.nmi(adata, label_key, col)
+        if nmi > nmi_max:
+            nmi_max = nmi
+            cluster_key = col
+
+    score = scib.me.nmi(
         adata=adata,
         label_key=label_key,
         cluster_key=cluster_key,
-        metric=scib.me.nmi,
-        use_rep=None,
     )
     return scib.me.nmi(
         adata=adata[adata.obs[label_key].notna()],

--- a/workflow/metrics/scripts/prepare.py
+++ b/workflow/metrics/scripts/prepare.py
@@ -23,7 +23,6 @@ def compute_pca(adata, matrix):
 input_file = snakemake.input[0]
 output_file = snakemake.output[0]
 params = snakemake.params
-# label_key = params.get('label_key')
 neighbor_args = params.get('neighbor_args', {})
 unintegrated_layer = params.get('unintegrated_layer', 'X')
 corrected_layer = params.get('corrected_layer', 'X')
@@ -137,6 +136,12 @@ compute_neighbors(
     check_n_neighbors=False,
     **neighbor_args
 )
+
+# remove any obsm keys except for X_pca and X_emb to save space
+for key in list(adata.obsm.keys()):
+    if key in ['X_pca', 'X_emb']:
+        continue
+    del adata.obsm[key]
 
 logging.info(f'Write to {output_file}...')
 logging.info(adata.__str__())

--- a/workflow/metrics/scripts/run.py
+++ b/workflow/metrics/scripts/run.py
@@ -89,6 +89,8 @@ logger.info(f'Read {input_file} of input_type {input_type}...')
 adata = read_anndata(input_file, **kwargs)
 if 'feature_name' in adata.var.columns:
     adata.var_names = adata.var['feature_name'].astype(str)
+obs_mask = ~adata.obs[batch_key].isna()
+adata = adata[obs_mask].copy()
 print(adata, flush=True)
 
 adata_raw = None
@@ -107,12 +109,14 @@ if 'raw' in snakemake.input.keys():
 
     # assemble PCA for unintegrated
     adata_raw.obsm['X_pca'] = read_anndata(raw_file, X='obsm/X_pca').X
-    adata_raw.obs = adata.obs
     assert_pca(adata_raw)
     
+    # deal with metadata
+    adata_raw = adata_raw[obs_mask].copy()
+    adata_raw.obs = adata.obs
     if 'feature_name' in adata_raw.var.columns:
         adata_raw.var_names = adata_raw.var['feature_name'].astype(str)
-
+    
 
 # set default covariates
 if use_covariate and len(covariates) == 0:
@@ -130,8 +134,6 @@ adata.obs = adata.obs[columns].copy()
 adata.obs.rename(columns=lambda x: replace_last(x, '_1', ''), inplace=True)
 
 logger.info(f'Run metric {metric} for {output_type}...')
-adata.obs[batch_key] = adata.obs[batch_key].astype(str)
-
 # TODO: deal with bootstrapping
 scores = metric_function(
     adata,

--- a/workflow/metrics/scripts/score_genes.py
+++ b/workflow/metrics/scripts/score_genes.py
@@ -31,9 +31,10 @@ output_file = snakemake.output[0]
 params = snakemake.params
 unintegrated_layer = params.get('unintegrated_layer', 'X')
 raw_counts_layer = params.get('raw_counts_layer', unintegrated_layer)
-var_key = params.get('var_mask', 'highly_variable')
 gene_sets = params['gene_sets']
 n_random_permutations = params.get('n_permutations', 100)
+n_random_genes = params.get('n_random_genes', 50)
+ctrl_size = params.get('ctrl_size', 50)
 n_quantiles = params.get('n_quantiles', 2)
 MAX_OBS = int(params.get('MAX_OBS', 4e6))
 

--- a/workflow/metrics/scripts/score_genes.py
+++ b/workflow/metrics/scripts/score_genes.py
@@ -4,7 +4,6 @@ logging.basicConfig(level=logging.INFO)
 import numpy as np
 import anndata as ad
 from tqdm import tqdm
-from scipy import sparse
 
 from metrics.bootstrap import get_bootstrap_adata
 from utils.io import read_anndata, write_zarr_linked
@@ -99,11 +98,17 @@ if adata.n_obs > MAX_OBS:
 
 # Extract control genes and precompute random sets
 control_genes = adata.var_names[~adata.var_names.isin(genes)].tolist()
+effective_n_random_genes = min(n_random_genes, len(control_genes))
+if effective_n_random_genes < n_random_genes:
+    logger.warning(
+        f'Only {len(control_genes)} control genes available, '
+        f'reducing n_random_genes from {n_random_genes} to {effective_n_random_genes}'
+    )
 random_gene_sets = [
-    np.random.choice(control_genes, size=n_random_genes, replace=False)
+    np.random.choice(control_genes, size=effective_n_random_genes, replace=False)
     for _ in range(n_random_permutations)
 ]
-all_random_genes = set().union(*random_gene_sets)
+all_random_genes = set().union(*random_gene_sets) if random_gene_sets else set()
 
 # Include additional control genes for validation
 n_control = min(ctrl_size, sum(1 for g in control_genes if g not in all_random_genes))
@@ -125,8 +130,9 @@ for random_genes in random_gene_sets:
         ctrl_size=ctrl_size
     )
     random_scores.append(adata.obs['score'].values)
-del adata.obs['score']
-adata.obsm['random_gene_scores'] = sparse.csr_matrix(np.vstack(random_scores).T)
+if 'score' in adata.obs.columns:
+    del adata.obs['score']
+adata.obsm['random_gene_scores'] = np.stack(random_scores, axis=1) if random_scores else np.empty((adata.n_obs, 0))
 logging.info(f'Stored {len(random_scores)} random gene score sets in obsm')
 
 # Score gene sets of interest

--- a/workflow/metrics/scripts/score_genes.py
+++ b/workflow/metrics/scripts/score_genes.py
@@ -97,56 +97,52 @@ if adata.var_names.duplicated().sum() > 0:
 if adata.n_obs > MAX_OBS:
     adata = get_bootstrap_adata(adata, size=MAX_OBS)
 
-# subset to HVGs (used for control genes) + genes of interest
-logging.info(f'Subset to {adata.n_vars} genes for scoring')
-logging.debug(adata.__str__())
-assert var_key in adata.var.columns, f'var_key "{var_key}" not in adata.var columns: {adata.var.columns}'
-adata.var.loc[adata.var_names.isin(genes), var_key] = True
-adata = adata[:, adata.var[var_key]].copy()
+# Extract control genes and precompute random sets
+control_genes = adata.var_names[~adata.var_names.isin(genes)].tolist()
+random_gene_sets = [
+    np.random.choice(control_genes, size=n_random_genes, replace=False)
+    for _ in range(n_random_permutations)
+]
+all_random_genes = set().union(*random_gene_sets)
 
-# Compute matrix
+# Include additional control genes for validation
+n_control = min(ctrl_size, sum(1 for g in control_genes if g not in all_random_genes))
+control_reserve = [g for g in control_genes if g not in all_random_genes][:n_control]
+
+# Subset adata and prepare for scoring
+genes_for_scoring = set(genes) | all_random_genes | set(control_reserve)
+adata = adata[:, adata.var_names.isin(genes_for_scoring)].copy()
+logging.info(f'Subset to {adata.n_vars} genes ({len(genes)} from user + {len(all_random_genes)} random + {n_control} control)')
 adata = dask_compute(adata, layers='X')
 
-for set_name, gene_list in tqdm(gene_sets.items(), desc='Compute Gene scores', miniters=1):
-    n_genes = len(gene_list)
-    if n_genes == 0:
-        logging.info(f'Gene set with {n_genes} genes is too small, skip')
+# Score random gene sets
+logging.info('Computing random gene scores...')
+random_scores = []
+for random_genes in random_gene_sets:
+    sc.tl.score_genes(
+        adata,
+        gene_list=random_genes,
+        ctrl_size=ctrl_size
+    )
+    random_scores.append(adata.obs['score'].values)
+del adata.obs['score']
+adata.obsm['random_gene_scores'] = sparse.csr_matrix(np.vstack(random_scores).T)
+logging.info(f'Stored {len(random_scores)} random gene score sets in obsm')
+
+# Score gene sets of interest
+for set_name, gene_list in tqdm(gene_sets.items(), desc='Gene scores'):
+    if len(gene_list) == 0:
+        logging.warning(f'Gene set "{set_name}" is empty, skipping')
         continue
-    
-    logging.info(f'Gene score for gene set with {len(gene_list)} genes...')
     sc.tl.score_genes(
         adata,
         gene_list=gene_list,
+        ctrl_size=ctrl_size,
         score_name=f'gene_score:{set_name}'
     )
 
-    logging.info('Add random gene scores...')
-    random_key = f'random_gene_scores:{n_genes}'
-    if random_key in adata.obsm.keys():
-        logging.info(f'Random gene scores for {n_genes} genes already computed, skip')
-        continue
-    
-    scores = []
-    for _ in range(n_random_permutations):
-        sc.tl.score_genes(
-            adata,
-            gene_list=np.random.choice(
-                adata.var_names,
-                size=n_genes,
-                replace=False
-            )
-        )
-        scores.append(adata.obs['score'].values)
-    del adata.obs['score']
-    adata.obsm[random_key] = sparse.csr_matrix(np.vstack(scores).T)
-
-# logging.info('Bin expression...')
+# Final subset to genes of interest only
 adata = adata[:, genes].copy()
-# adata = dask_compute(adata[:, genes].copy(), layers='raw_counts')
-# adata.X = bins_by_quantiles(
-#     adata.layers['raw_counts'].toarray(),
-#     n_quantiles=n_quantiles,
-# )
 
 logging.info(f'Write to {output_file}...')
 logging.info(adata.__str__())

--- a/workflow/metrics/test/config.yaml
+++ b/workflow/metrics/test/config.yaml
@@ -34,6 +34,7 @@ defaults:
   datasets:
     - test_metrics
     - test_clustering_metrics
+    - test_clustering_precomputed
     - test_integration
     - scib_metrics
     - morans_i
@@ -70,6 +71,21 @@ DATASETS:
         - isolated_label_f1
         - graph_connectivity
   
+  test_clustering_precomputed:
+    input:
+      metrics: test/input/pbmc68k.h5ad
+    metrics:
+      label: bulk_labels
+      batch: batch
+      output_type: full
+      recompute_neighbors: true
+      clustering:
+        precomputed_key: bulk_labels
+      metrics:
+        - nmi
+        - ari
+        - graph_connectivity
+  
   test_integration:
     input:
       metrics:
@@ -80,7 +96,7 @@ DATASETS:
         harmony: test/input/integration/dataset~harmony/file_id~3bd5f9cfa3/batch~batch/var_mask~highly_variable/method~harmonypy--hyperparams~6e507e5a19--label~None--output_type~embed.zarr
         # scanorama_full: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~scanorama--hyperparams~a90b47ca49--label~None--output_type~full.zarr
         # scanorama_embed: test/input/integration/dataset~test/file_id~pbmc68k/batch~batch/var_mask~highly_variable/method~scanorama--hyperparams~a90b47ca49--label~None--output_type~embed.zarr
-        scvi: test/input/integration/dataset~scvi_tools/file_id~orig/batch~batch/var_mask~highly_variable/method~scvi--hyperparams~5604fd8c38--label~None--output_type~embed.zarr
+        scvi: test/input/integration/dataset~scvi_tools/file_id~orig/batch~batch/var_mask~highly_variable/method~scvi--hyperparams~11e9065eea--label~None--output_type~embed.zarr
     metrics:
       unintegrated: layers/normcounts
       raw_counts: layers/counts


### PR DESCRIPTION
- [x] Fix `replace_last()` in `isolated_labels.py` to return the original string unchanged when `replace_what` isn't found (remove incorrect `_orig` suffix appending)
- [x] Simplify random gene sampling in `score_genes.py`: clamp `n_random_genes` to available control genes, handle empty `n_random_permutations`, replace `sparse.csr_matrix(np.vstack(...).T)` with `np.stack(..., axis=1)`, remove unused `scipy.sparse` import