### PR TITLE
Load data: schema_file optional

### DIFF
--- a/workflow/load_data/rules/load_data.smk
+++ b/workflow/load_data/rules/load_data.smk
@@ -29,24 +29,23 @@ def get_files_for_metadata_harm(wildcards):
         )
     file_path = meta['url']
     anno_file = meta.get('annotation_file')
+    schema_file = config.get('schema_file')
 
     # download file if not present
     if not Path(str(file_path)).exists():
         file_path = rules.download.output.h5ad
 
+    file_map = {'h5ad': file_path}
+
     # include annotation file if specified
     if pd.notna(anno_file) and pd.notnull(anno_file):
-        return {
-            'h5ad': file_path,
-            'schema': config["schema_file"],
-            'annotation_file': anno_file,
-        }
+        file_map['annotation_file'] = anno_file
 
-    # default files
-    return {
-        'h5ad': file_path,
-        'schema': config["schema_file"],
-    }
+    # include schema file if specified
+    if pd.notna(schema_file) and pd.notnull(schema_file):
+        file_map['schema'] = schema_file
+
+    return file_map
 
 
 rule harmonize_metadata:

--- a/workflow/load_data/scripts/harmonize_metadata.py
+++ b/workflow/load_data/scripts/harmonize_metadata.py
@@ -16,7 +16,7 @@ from utils.io import read_anndata, write_zarr
 from utils.misc import ensure_sparse, dask_compute
 
 in_file = snakemake.input.h5ad
-schema_file = snakemake.input.schema
+schema_file = snakemake.input.get('schema')
 annotation_file = snakemake.input.get('annotation_file')
 out_file = snakemake.output.zarr
 # out_plot = snakemake.output.plot
@@ -107,7 +107,7 @@ else:
 
 # Checking schema version
 if 'schema_version' not in adata.uns.keys():
-    adata.uns['schema_version'] = '0.0.0'
+    adata.uns['schema_version'] = float('nan')
 if adata.uns['schema_version'] == '2.0.0':
     adata.obs['self_reported_ethnicity'] = adata.obs['ethnicity']
     adata.obs['self_reported_ethnicity_ontology_term_id'] = adata.obs['ethnicity_ontology_term_id']
@@ -136,13 +136,14 @@ if 'barcode' not in adata.obs.columns:
 adata.obs_names = adata.obs[['barcode', 'tech_id']].astype(str).agg('-'.join, axis=1)
 
 # schemas translation
-schemas_df = pd.read_table(schema_file).dropna()
-logging.info(schemas_df)
-from_schema = meta['schema']
-assert from_schema in schemas_df.columns
-to_schema = 'cellxgene'
-SCHEMAS["NAMES"] = dict(zip(schemas_df[from_schema], schemas_df[to_schema]))
-adata.obs.rename(SCHEMAS["NAMES"], inplace=True)
+if schema_file is not None:
+    schemas_df = pd.read_table(schema_file).dropna()
+    logging.info(schemas_df)
+    from_schema = meta['schema']
+    assert from_schema in schemas_df.columns
+    to_schema = 'cellxgene'
+    SCHEMAS["NAMES"] = dict(zip(schemas_df[from_schema], schemas_df[to_schema]))
+    adata.obs.rename(SCHEMAS["NAMES"], inplace=True)
 
 # making sure all columns are in the object
 all_columns = get_union(SCHEMAS["CELLxGENE_OBS"], SCHEMAS["TIER1"], SCHEMAS["EXTRA_COLUMNS"])

--- a/workflow/load_data/test/configs/cellxgene_no_schema.yaml
+++ b/workflow/load_data/test/configs/cellxgene_no_schema.yaml
@@ -1,0 +1,5 @@
+output_dir: test/out
+dataset_meta: test/configs/dataset_info/cellxgene_no_schema.tsv
+images: test/images
+
+env_mode: local # from_yaml

--- a/workflow/load_data/test/configs/dataset_info/cellxgene_no_schema.tsv
+++ b/workflow/load_data/test/configs/dataset_info/cellxgene_no_schema.tsv
@@ -1,0 +1,3 @@
+subset	organ	dataset	study	collection_name	doi	cxg_url	collection_id	dataset_id	project_uuid	modalities	pipeline_version	reference	donor_column	tech_id	keep_covariates	author_annotation	institution	url	annotation_file	barcode_column	schema
+test	lung	Nawijn_2021_cellxgene	Nawijn_2021	HLCA	10.1038/s41591-019-0468-5					RNA	Cell Ranger v3.1.0	GRCh38-ensembl84	subject_ID	sample		original_ann_level_1	University Medical Center Groningen	test/data/Nawijn_2021.h5ad			cellxgene
+

--- a/workflow/load_data/test/run_test_cellxgene_no_schema.sh
+++ b/workflow/load_data/test/run_test_cellxgene_no_schema.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Test that harmonize_metadata succeeds when schema_file is omitted
+# (i.e. the dataset is already in the target CELLxGENE schema)
+set -e -x
+
+WORKDIR=$(dirname $(dirname $0))
+cd $WORKDIR
+
+snakemake --configfile test/configs/cellxgene_no_schema.yaml --rerun-incomplete --use-conda --printshellcmds $@
+
+conda run -n scanpy python test/run_assertions.py --live-stream


### PR DESCRIPTION
Makes the `schema_file` input optional in the load-data harmonization step, allowing datasets that are already in the target schema to run without requiring a schema-mapping TSV.

## Changes Made

- Treat `schema` as an optional Snakemake input and only apply column-translation when provided.
- Update the Snakemake input-function to only include the schema mapping file when configured.
- Add a test config (`cellxgene_no_schema.yaml`) that omits `schema_file`, using a local CELLxGENE-schema dataset (`Nawijn_2021.h5ad`), to exercise the no-schema code path and catch regressions.