### PR TITLE
Pin scipy<1.17 in scanpy/scib/bbknn/scanorama/pegasus envs (refs #366)

### DIFF
--- a/envs/bbknn.yaml
+++ b/envs/bbknn.yaml
@@ -12,6 +12,7 @@ dependencies:
   - dask
   - dask-ml
   - sparse
+  - scipy<1.17
   - pip
   - pip:
     - torch

--- a/envs/cellhint.yaml
+++ b/envs/cellhint.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.11
   - anndata=0.11
   - scanpy=1.11
+  - scipy<1.17
   - leidenalg
   - dask
   - sparse

--- a/envs/celltypist.yaml
+++ b/envs/celltypist.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.11
   - anndata=0.11
   - scanpy=1.11
+  - scipy<1.17
   - leidenalg
   - dask
   - sparse

--- a/envs/gloscope.yaml
+++ b/envs/gloscope.yaml
@@ -11,6 +11,7 @@ dependencies:
   - python=3.12
   - anndata>=0.11
   - scanpy >=1.11
+  - scipy<1.17
   - hdf5=1.14.2
   - dask
   - dask-ml

--- a/envs/pegasus.yaml
+++ b/envs/pegasus.yaml
@@ -9,6 +9,7 @@ dependencies:
   - dask<2024.8
   - dask-ml
   - sparse
+  - scipy<1.17
   - zarr<3
   - pandas<2.0
   - numpy<2.0

--- a/envs/pilot.yaml
+++ b/envs/pilot.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.11.9
   - anndata=0.10
   - scanpy=1.9.6
+  - scipy<1.17
   - leidenalg
   - faiss-cpu
   - dask

--- a/envs/plots.yaml
+++ b/envs/plots.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.11
   - scanpy=1.11
+  - scipy<1.17
   - anndata=0.11
   - zarr<3
   - pandas<3

--- a/envs/sample_representation.yaml
+++ b/envs/sample_representation.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.11.9
   - anndata=0.10
   - scanpy=1.10
+  - scipy<1.17
   - leidenalg
   - faiss-cpu
   - dask<2024.8

--- a/envs/scanorama.yaml
+++ b/envs/scanorama.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pandas<3
   - dask
   - sparse
+  - scipy<1.17

--- a/envs/scanpy.yaml
+++ b/envs/scanpy.yaml
@@ -12,6 +12,7 @@ dependencies:
   - dask<2024.8
   - dask-ml
   - sparse
+  - scipy<1.17
   - zarr<3
   - pandas<3
   - harmony-pytorch

--- a/envs/scarches.yaml
+++ b/envs/scarches.yaml
@@ -7,6 +7,7 @@ dependencies:
   - python=3.11
   - anndata=0.11
   - scanpy=1.11
+  - scipy<1.17
   - zarr<3
   - pandas<3
   - dask

--- a/envs/scib.yaml
+++ b/envs/scib.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pandas<3
   - dask
   - sparse
+  - scipy<1.17
   - pip
   - pip:
     - git+https://github.com/theislab/scib.git@main

--- a/envs/scib_metrics.yaml
+++ b/envs/scib_metrics.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.11
   - anndata=0.11
   - scanpy=1.11
+  - scipy<1.17
   - zarr<3
   - pandas<3
   - dask

--- a/envs/scitd.yaml
+++ b/envs/scitd.yaml
@@ -11,6 +11,7 @@ dependencies:
   - python=3.10
   - anndata>=0.10.0
   - scanpy >=1.10.0
+  - scipy<1.17
   - dask
   - dask-ml
   - sparse


### PR DESCRIPTION
While running the quickstart on CPU, I hit `AttributeError: 'backed_csr_matrix' object has no attribute '_validate_indices'` (#366) in workflows using scanpy/anndata sparse paths. Pinning scipy<1.17 (landed 1.16.3) resolves it.

Note: I have not tested this beyond the quickstart conda environments utilized.  Other envs in this repo (qc, rapids_singlecell, scvi-tools, scvi-vitkl) were not tested in this pass — scvi-tools already pins scipy<1.15 via the scvi-tools package. If others hit #366 in the untested envs, the same one-line pin should apply, but I didn't want to speculatively pin envs I hadn't run.