### PR TITLE
Fix ari_kmeans_y: import full scib_metrics module to match

### DIFF
--- a/workflow/metrics/scripts/metrics/ari.py
+++ b/workflow/metrics/scripts/metrics/ari.py
@@ -39,7 +39,7 @@ def ari_leiden_y(adata, output_type, batch_key, label_key, **kwargs):
 
 
 def ari_kmeans_y(adata, output_type, batch_key, label_key, **kwargs):
-    from scib_metrics import nmi_ari_cluster_labels_kmeans
+    import scib_metrics
     
     labels = rename_categories(adata, label_key)
     adata = select_neighbors(adata, output_type)


### PR DESCRIPTION
`ari_kmeans_y` called `scib_metrics.nmi_ari_cluster_labels_kmeans()` but imported the function via `from scib_metrics import nmi_ari_cluster_labels_kmeans`.  Changed to `import scib_metrics` to match the pattern in `ari_leiden_y` directly above. 