### PR TITLE
pcr_y: use precomputed obsm['X_pca'] instead of raw .X

### DIFF
--- a/workflow/metrics/scripts/metrics/pcr.py
+++ b/workflow/metrics/scripts/metrics/pcr.py
@@ -39,11 +39,10 @@ def pcr_y(adata, output_type, batch_key, label_key, adata_raw, **kwargs):
 
     if output_type == 'knn':
         return np.nan
-    
-    adata_raw = dask_compute(adata_raw, layers='X')
-    X_pre = adata_raw.X
-    X_post = adata.obsm['X_emb'] if output_type == 'embed' else adata.X
-    X_pre, X_post = [X if isinstance(X, np.ndarray) else X.todense() for X in [X_pre, X_post]]
+
+    X_pre = adata_raw.obsm['X_pca']
+    X_post = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
+    X_pre, X_post = [X if isinstance(X, np.ndarray) else np.asarray(X.todense()) for X in [X_pre, X_post]]
 
     return scib_metrics.pcr_comparison(
         X_pre=X_pre,


### PR DESCRIPTION
I'm trying to get everything up and running on an HPC, turning on GPU support and debugging. I ran a pass with all GPU accelerated parameters (_y) except `ari_kmeans_y`, `nmi_kmeans_y` (see #370). I'm using a 4 sample, ~60k cell dataset. I'm currently only using 4 integration methods (unintegrated baseline, harmonypy, scVI, scANVI). 

The error I ran into, which led to this proposed fix:

```
Traceback (most recent call last):
  File ".../tmpkp3znna0.run.py", line 140, in <module>
    scores = metric_function(...)
  File ".../workflow/metrics/rules/../scripts/metrics/pcr.py", line 46, in pcr_y
    X_pre, X_post = [X if isinstance(X, np.ndarray) else X.todense() for X in [X_pre, X_post]]
  File ".../scripts/metrics/pcr.py", line 46, in <listcomp>
    X_pre, X_post = [X if isinstance(X, np.ndarray) else X.todense() for X in [X_pre, X_post]]
                                                         ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'todense'
```

Looking at the output from the run, I noted that 2 metrics ran to completion (harmonypy, unintegrated) while 2 failed (scVI, scANVI I believe). 

In the current `pcr_y` function, I thought the error came from `dask_compute`, that returned None.  However, it doesn't change the output unless it is a `dask.Array`. In other words: None-in → None-out. So it had to be come from upstream: `adata_raw.X` 

`adata_raw` comes from `workflow/metrics/scripts/run.py` → `get_metric_input`: 

```python
# rules/metrics.smk
if mcfg.get_from_parameters(wildcards, 'comparison', default=False):
    files['raw'] = rules.metrics_pca.output.zarr
```

 `pca.zarr`  is the HVG-subsetted PCA on unintegrated data. I inspected the `pca.zarr` for the scVI/scANVI integrations and confirmed `obsm/X_pca` is populated but the `X` slot is empty. In other situations, such as the haromypy scenario, it is populated and the run completes. However, I've concerns about the output being dubious in that case (see below). 

The fix is straightforward and mirrors what every other `_y` metric does in the `workflow/metrics/scripts/metrics/`: consumes `adata_raw` via `obsm['X_pca']` (not via `.X`). The `pcr_y` seems to be the sole exception to this pattern. The downstream code uses a second `read_anndata` call with X='obsm/X_pca` fits with the original code being a small bug. 

Regarding the harmonypy output and my concerns that it is not real: 
`scib_metrics.pcr_comparison` expects `X_pre` and `X_post` to be representations of the same kind. In the current code, `X_pre` has the raw HVG counts (much larger) and `X_post` has the low-dimension integrated embedding. I think the resulting metrics will be dominated by dimensionality/scale and not the integration quality. Fortunately, the CPU-side equivalent is (I believe) doing it correctly: using `obsm['X_pca']` and not raw `.X`. 

Any prior benchmarks using the above GPU accelerated code are probably dubious and need recalculated after this PR. 

