### PR TITLE
Handle empty .var from integration outputs in metrics prepare

### DIFF
--- a/workflow/metrics/scripts/prepare.py
+++ b/workflow/metrics/scripts/prepare.py
@@ -104,8 +104,20 @@ if var_key is None:
     )
     adata.var[var_key] = True
 else:
-    assert var_key in adata.var.columns, \
-        f'"{var_key}" not in adata var columns: {adata.var.columns.tolist()}'
+    if var_key not in adata.var.columns:
+        if adata.var.shape[1] == 0:
+            # Integration output has empty .var (features already subsetted by
+            # var_mask during integration_prepare); treat all remaining genes
+            # as selected, matching the var_key=None branch above.
+            logging.info(
+                f'adata.var has no columns; assuming integration already applied '
+                f'"{var_key}" mask, setting all True'
+            )
+            adata.var[var_key] = True
+        else:
+            raise AssertionError(
+                f'"{var_key}" not in adata var columns: {adata.var.columns.tolist()}'
+            )
 
 logging.info(f'Set "{var_key}" in adata.var: {adata.var[var_key].sum()} HVGs')
 

--- a/workflow/utils/accessors.py
+++ b/workflow/utils/accessors.py
@@ -115,6 +115,11 @@ def subset_hvg(
     if var_column is None or var_column == 'None':
         var_column = 'mask'
         adata.var[var_column] = True
+    elif var_column not in adata.var.columns and adata.var.shape[1] == 0:
+        # Integration has already subsetted features; no .var columns survived.
+        # Treat as if the mask was applied (all remaining genes selected),
+        # mirroring the var_column=None branch above.
+        adata.var[var_column] = True
     assert var_column in adata.var.columns, f'Column {var_column} not found in adata.var'
     assert adata.var[var_column].dtype == bool, f'Column {var_column} is not boolean'
     


### PR DESCRIPTION
Embedding-only integration outputs carry no feature metadata (empty .var). metrics prepare then crashes when subset_hvg tries to filter on the absent highly_variable column. This guards the empty-.var case in subset_hvg (utils/accessors.py) and the prepare script so HVG subsetting passes through instead of erroring.