### PR TITLE
Fix ari_kmeans_y and nmi_kmeans_y 

### DIFF
--- a/workflow/metrics/params.tsv
+++ b/workflow/metrics/params.tsv
@@ -16,9 +16,9 @@ morans_i_genes	bio_conservation	full,embed,knn	full,knn	False	False	False	True	s
 morans_i_random	batch_correction	full,embed,knn	knn	False	False	False	False	scib	cpu	1
 morans_i_genescore	bio_conservation	full,embed,knn	knn	False	False	False	True	scanpy	cpu	1
 ari_leiden_y	bio_conservation	full,embed,knn	knn	False	False	False	False	scib_metrics	gpu	1
-ari_kmeans_y	bio_conservation	full,embed,knn	knn	False	False	False	False	scib_metrics	gpu	1
+ari_kmeans_y	bio_conservation	full,embed	embed	False	False	False	False	scib_metrics	gpu	1
 nmi_leiden_y	bio_conservation	full,embed,knn	knn	False	False	False	False	scib_metrics	gpu	1
-nmi_kmeans_y	bio_conservation	full,embed,knn	knn	False	False	False	False	scib_metrics	gpu	1
+nmi_kmeans_y	bio_conservation	full,embed	embed	False	False	False	False	scib_metrics	gpu	1
 asw_label_y	bio_conservation	full,embed	embed	False	False	False	False	scib_metrics	gpu	1
 asw_batch_y	batch_correction	full,embed	embed	False	False	False	False	scib_metrics	gpu	1
 bras_batch	batch_correction	full,embed	embed	False	False	False	False	scib_metrics	gpu	1

--- a/workflow/metrics/scripts/metrics/ari.py
+++ b/workflow/metrics/scripts/metrics/ari.py
@@ -39,7 +39,7 @@ def ari_leiden_y(adata, output_type, batch_key, label_key, **kwargs):
 
 
 def ari_kmeans_y(adata, output_type, batch_key, label_key, **kwargs):
-    from scib_metrics import nmi_ari_cluster_labels_kmeans
+    import scib_metrics
     
     labels = rename_categories(adata, label_key)
     adata = select_neighbors(adata, output_type)

--- a/workflow/metrics/scripts/metrics/ari.py
+++ b/workflow/metrics/scripts/metrics/ari.py
@@ -41,11 +41,15 @@ def ari_leiden_y(adata, output_type, batch_key, label_key, **kwargs):
 def ari_kmeans_y(adata, output_type, batch_key, label_key, **kwargs):
     import scib_metrics
     
+    if output_type == 'knn':
+        return np.nan
+
     labels = rename_categories(adata, label_key)
-    adata = select_neighbors(adata, output_type)
+    X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
+    X = X if isinstance(X, np.ndarray) else np.asarray(X.todense())
 
     scores = scib_metrics.nmi_ari_cluster_labels_kmeans(
-        X=scanpy_to_neighborsresults(adata),
+        X=X,
         labels=labels,
     )
     return scores['ari']

--- a/workflow/metrics/scripts/metrics/nmi.py
+++ b/workflow/metrics/scripts/metrics/nmi.py
@@ -47,11 +47,12 @@ def nmi_leiden_y(adata, output_type, batch_key, label_key, **kwargs):
 def nmi_kmeans_y(adata, output_type, batch_key, label_key, **kwargs):
     import scib_metrics
 
-    labels = rename_categories(adata, label_key)
-    adata = select_neighbors(adata, output_type)
+    if output_type == 'knn':
+        return np.nan
 
-    X = adata.obsp['connectivities']
-    X = X if isinstance(X, np.ndarray) else X.toarray()
+    labels = rename_categories(adata, label_key)
+    X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
+    X = X if isinstance(X, np.ndarray) else np.asarray(X.todense())
 
     scores = scib_metrics.nmi_ari_cluster_labels_kmeans(
         X=X,


### PR DESCRIPTION
On my testing, I found that `ari_kmeans_y` and `nmi_kmeans_y` were broken three ways:

1. ari.py's scib_metrics import doesn't match the call site → ari_kmeans_y NameErrors. (This is #369, which I'll close after opening this)
2. Both pass the neighbor graph to `scib_metrics.nmi_ari_cluster_labels_kmeans`, which expects an embedding (n_obs x n_features); kmeans on a graph object raises a sklearn ValueError or OOMs materializing an NxN distance matrix. Now clusters `obsm['X_emb']`/`obsm['X_pca']`, with a guard so graph-only (knn) outputs are skipped rather than mis-scored.
3. params.tsv routed `kmeans_y` to `input_type=knn` (seemingly copied from the `leiden_y` rows), so `obsm` was never loaded. Corrected to `input_type=embed`, `allowed_output_types=full,embed.`