### PR TITLE
Fix scanpy_to_neighborsresults neighbor convention

### DIFF
--- a/workflow/metrics/scripts/metrics/utils.py
+++ b/workflow/metrics/scripts/metrics/utils.py
@@ -52,22 +52,29 @@ def select_neighbors(adata, output_type):
 
 def scanpy_to_neighborsresults(adata):
     from scib_metrics.nearest_neighbors import NeighborsResults
-    
+
     n_neighbors = adata.uns["neighbors"]["params"]["n_neighbors"]
     n_obs = adata.n_obs
-    
-    # convert sparse to dense neighbor lists
-    distances = np.full((n_obs, n_neighbors), np.inf)
-    indices = np.full((n_obs, n_neighbors), -1)
-
-    # use scanpy's stored distances (CSR sparse)
     dist_matrix = adata.obsp["distances"].tocsr()
 
+    # scib_metrics expects each cell as neighbor 0 (distance 0), n_neighbors columns total.
+    # scanpy stores n_neighbors-1 off-diagonal neighbors (self excluded); some backends
+    # (e.g. rapids) may include self. Force the convention regardless of backend.
+    indices = np.full((n_obs, n_neighbors), -1, dtype=int)
+    distances = np.full((n_obs, n_neighbors), np.inf, dtype=float)
+    indices[:, 0] = np.arange(n_obs)
+    distances[:, 0] = 0.0
+
+    indptr = dist_matrix.indptr
     for i in range(n_obs):
-        row = dist_matrix[i].indices
-        dists = dist_matrix[i].data
-        order = np.argsort(dists)[:n_neighbors]  # sort neighbors by distance
-        indices[i, :len(order)] = row[order]
-        distances[i, :len(order)] = dists[order]
+        sl = slice(indptr[i], indptr[i + 1])
+        row = dist_matrix.indices[sl]
+        d = dist_matrix.data[sl]
+        keep = row != i                            # drop self if the backend stored it
+        row, d = row[keep], d[keep]
+        order = np.argsort(d)[: n_neighbors - 1]   # K-1 nearest non-self
+        k = len(order)
+        indices[i, 1 : 1 + k] = row[order]
+        distances[i, 1 : 1 + k] = d[order]
 
     return NeighborsResults(indices=indices, distances=distances)


### PR DESCRIPTION
`scanpy_to_neighborsresults` converts a scanpy/rapids neighbor graph into a `scib_metrics` `NeighborsResults`, but the output didn't match the convention `scib_metrics` uses. I verified this against `scib_metrics.nearest_neighbors.pynndescent`, which places each cell as its own neighbor 0 (distance 0). 

There were two coupled defects: it allocates `n_neighbors` columns but scanpy's `obsp['distances']` holds only n_neighbors-1 entries (self excluded), so 
1. column 0 is the nearest non-self neighbor (an off-by-one shift) 
2. the final column is never filled, staying at the -1 index / inf distance padding. 

A -1 index silently gathers the last cell in the dataset as a neighbor of every cell. I believe this affects every knn-based _y metric (iLISI, cLISI, kBET, graph connectivity, leiden ARI/NMI) fed scanpy-computed neighbors. The fix forces the convention regardless of backend: self at column 0, then the n_neighbors-1 nearest non-self neighbors (dropping self if the backend included it). 

This was verified on a toy dataset that the corrected output matches pynndescent and an sklearn self-inclusive kNN reference.