### PR TITLE
Score_genes has undefined logger + duplicate-feature var mask

### DIFF
--- a/workflow/metrics/scripts/score_genes.py
+++ b/workflow/metrics/scripts/score_genes.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import logging
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 import numpy as np
 import anndata as ad
 from tqdm import tqdm
@@ -63,7 +64,9 @@ if 'feature_name' in adata.var.columns:
     adata.var_names = adata.var['feature_name'].astype(str).values
 
 all_obs_names = adata.obs_names.copy()
-all_var_names = adata.var_names.copy()
+# feature_name can be non-unique (CxG feature collisions); use unique feature_id for the
+# var subset_mask so duplicate columns dropped during dedup aren't double-counted.
+all_var_ids = adata.var['feature_id'].copy() if 'feature_id' in adata.var.columns else adata.var_names.copy()
 
 logging.debug('Parse gene sets...')
 logging.debug(f'Initial gene sets: {gene_sets}')
@@ -153,7 +156,8 @@ adata = adata[:, genes].copy()
 logging.info(f'Write to {output_file}...')
 logging.info(adata.__str__())
 obs_mask = all_obs_names.isin(adata.obs_names)
-var_mask = all_var_names.isin(adata.var_names)
+final_var_ids = adata.var['feature_id'] if 'feature_id' in adata.var.columns else adata.var_names
+var_mask = np.asarray(all_var_ids.isin(final_var_ids))
 write_zarr_linked(
     adata,
     in_dir=input_file,


### PR DESCRIPTION
Found two bugs in metrics/scripts/score_genes.py:

1. The module configures logging but never assigns `logger`. `logger.info`/`logger.warning` are called and run unconditionally, so the script `NameErrors` on every invocation. All gene-set metrics (`pcr_genes`, `morans_i_genes`) are broken as a reuslt. 
2. When `feature_name` is non-unique (CxG/Ensembl-renamed data), the final `var_mask = all_var_names.isin(adata.var_names)` marks every position of a duplicated name True, including columns dropped during deduplication. As a result,  `sum(var_mask)` > `adata.n_vars` and the linked-zarr subset_mask mis-aligns.

Simple fixes: (1) define the module logger at the top and (2) build the mask from the unique `feature_id`