### PR TITLE
metrics: use .toarray() to avoid np.matrix from .todense()

### DIFF
--- a/workflow/metrics/scripts/metrics/asw.py
+++ b/workflow/metrics/scripts/metrics/asw.py
@@ -24,7 +24,7 @@ def asw_batch_y(adata, output_type, batch_key, label_key, **kwargs):
         return np.nan
 
     X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
-    X = X if isinstance(X, np.ndarray) else X.todense()
+    X = X if isinstance(X, np.ndarray) else X.toarray()
     labels = rename_categories(adata, label_key)
     batches = rename_categories(adata, batch_key)
 
@@ -56,7 +56,7 @@ def asw_label_y(adata, output_type, batch_key, label_key, **kwargs):
         return np.nan
 
     X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
-    X = X if isinstance(X, np.ndarray) else X.todense()
+    X = X if isinstance(X, np.ndarray) else X.toarray()
     labels = rename_categories(adata, label_key)
 
     return scib_metrics.silhouette_label(

--- a/workflow/metrics/scripts/metrics/bras.py
+++ b/workflow/metrics/scripts/metrics/bras.py
@@ -10,7 +10,7 @@ def bras_batch(adata, output_type, batch_key, label_key, **kwargs):
         return np.nan
     
     X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
-    X = X if isinstance(X, np.ndarray) else X.todense()
+    X = X if isinstance(X, np.ndarray) else X.toarray()
     labels = rename_categories(adata, label_key)
     batches = rename_categories(adata, batch_key)
 

--- a/workflow/metrics/scripts/metrics/isolated_labels.py
+++ b/workflow/metrics/scripts/metrics/isolated_labels.py
@@ -63,7 +63,7 @@ def isolated_label_asw_y(adata, output_type, batch_key, label_key, **kwargs):
         return np.nan
 
     X = adata.obsm['X_emb'] if output_type == 'embed' else adata.obsm['X_pca']
-    X = X if isinstance(X, np.ndarray) else X.todense()
+    X = X if isinstance(X, np.ndarray) else X.toarray()
 
     return scib_metrics.isolated_labels(
         X=X,


### PR DESCRIPTION
These three functions convert a sparse matrix to dense with `.todense()`, which returns a `np.matrix` rather than a plain `np.ndarray`. The `isinstance(X, np.ndarray)` check sitting right next to it is supposed to guarantee an ndarray, but `np.matrix` is a subclass, so it passes the check while still behaving differently from a normal array (it stays 2D, and `*` does matrix multiplication instead of elementwise) which can cause subtle bugs further down. `.toarray()` returns an ndarray directly, so this just makes the code do what that guard already intends. It's low-risk: nothing in the current pipeline visibly breaks on the `np.matrix`, but it brings `asw.py`, `bras.py`, and `isolated_labels.py` in line with the rest of the metrics module, which already steers clear of the bare `.todense()` form.